### PR TITLE
Removing organization attribute of Creator model

### DIFF
--- a/api/models/schema.py
+++ b/api/models/schema.py
@@ -83,7 +83,6 @@ class Creator(Person):
                                       options={"placeholder": orcid_pattern_placeholder},
                                       errorMessage={"pattern": orcid_pattern_error}
                                       )
-    organization: Optional[str] = Field(description="The organization that the creator is associated with.")
     email: Optional[EmailStr] = Field(description="A string containing an email address for the creator.")
     affiliation: Optional[Affiliation] = Field(description="The affiliation of the creator with the organization.")
 


### PR DESCRIPTION
We don't need 'organization' for Creator as we now have 'affiliation' attribute. 