### PR TITLE
Delete linked records

### DIFF
--- a/api/routes/catalog.py
+++ b/api/routes/catalog.py
@@ -1,6 +1,6 @@
 from typing import Annotated, List
 
-from beanie import DeleteRules, PydanticObjectId, WriteRules
+from beanie import PydanticObjectId, WriteRules
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from api.adapters.base import AbstractRepositoryMetadataAdapter
@@ -72,7 +72,9 @@ async def delete_dataset(submission_id: PydanticObjectId, user: Annotated[User, 
     dataset = await DatasetMetadataDOC.get(submission.identifier)
     if dataset is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dataset metadata record was not found")
-    await submission.delete(link_rule=DeleteRules.DELETE_LINKS)
+    user.submissions.remove(submission)
+    await user.save(link_rule=WriteRules.WRITE)
+    await submission.delete()
     await dataset.delete()
     return {"deleted_dataset_id": submission_id}
 

--- a/api/routes/catalog.py
+++ b/api/routes/catalog.py
@@ -1,6 +1,6 @@
 from typing import Annotated, List
 
-from beanie import PydanticObjectId
+from beanie import DeleteRules, PydanticObjectId, WriteRules
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from api.adapters.base import AbstractRepositoryMetadataAdapter
@@ -19,7 +19,7 @@ async def create_dataset(document: DatasetMetadataDOC, user: Annotated[User, Dep
     submission = document.as_submission()
     await submission.insert()
     user.submissions.append(submission)
-    await user.save()
+    await user.save(link_rule=WriteRules.WRITE)
     return document
 
 
@@ -72,7 +72,7 @@ async def delete_dataset(submission_id: PydanticObjectId, user: Annotated[User, 
     dataset = await DatasetMetadataDOC.get(submission.identifier)
     if dataset is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dataset metadata record was not found")
-    await submission.delete()
+    await submission.delete(link_rule=DeleteRules.DELETE_LINKS)
     await dataset.delete()
     return {"deleted_dataset_id": submission_id}
 
@@ -125,7 +125,7 @@ async def _save_to_db(identifier: str, user: User, submission: Submission = None
         submission = adapter.update_submission(submission=submission, repo_record_id=identifier)
         await submission.insert()
         user.submissions.append(submission)
-        await user.save()
+        await user.save(link_rule=WriteRules.WRITE)
         dataset = repo_dataset
     else:
         # update existing registration

--- a/api/routes/catalog.py
+++ b/api/routes/catalog.py
@@ -17,7 +17,6 @@ router = APIRouter()
 async def create_dataset(document: DatasetMetadataDOC, user: Annotated[User, Depends(get_current_user)]):
     await document.insert()
     submission = document.as_submission()
-    await submission.insert()
     user.submissions.append(submission)
     await user.save(link_rule=WriteRules.WRITE)
     return document
@@ -125,7 +124,6 @@ async def _save_to_db(identifier: str, user: User, submission: Submission = None
         await repo_dataset.insert()
         submission = repo_dataset.as_submission()
         submission = adapter.update_submission(submission=submission, repo_record_id=identifier)
-        await submission.insert()
         user.submissions.append(submission)
         await user.save(link_rule=WriteRules.WRITE)
         dataset = repo_dataset

--- a/docker/requirements/api.txt
+++ b/docker/requirements/api.txt
@@ -1,6 +1,6 @@
 fastapi[all]
 uvicorn[standard]
 motor
-beanie[httpx]
+beanie[httpx]==1.19.0
 python-jose
 pydantic<2.*

--- a/docker/requirements/triggers.txt
+++ b/docker/requirements/triggers.txt
@@ -1,5 +1,5 @@
 typer
-beanie
+beanie==1.19.0
 motor
 pydantic[dotenv]<2.*
 pydantic[email]<2.*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
+from beanie import DeleteRules
 
 from api.config import get_settings
 from api.main import app
@@ -39,7 +40,10 @@ async def client_test():
 
         # cleanup the test db collections
         await CoreMetadataDOC.find(with_children=True).delete()
-        await Submission.find().delete()
+
+        submissions = await Submission.find().to_list()
+        for submission in submissions:
+            await submission.delete(link_rule=DeleteRules.DELETE_LINKS)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from httpx import AsyncClient
-from beanie import DeleteRules
+from beanie import WriteRules
 
 from api.config import get_settings
 from api.main import app
@@ -40,10 +40,12 @@ async def client_test():
 
         # cleanup the test db collections
         await CoreMetadataDOC.find(with_children=True).delete()
-
-        submissions = await Submission.find().to_list()
-        for submission in submissions:
-            await submission.delete(link_rule=DeleteRules.DELETE_LINKS)
+        user = await User.find_one(
+            User.access_token == TEST_ACCESS_TOKEN, fetch_links=True
+        )
+        user.submissions.clear()
+        await user.save(link_rule=WriteRules.WRITE)
+        await Submission.find().delete()
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/test_dataset_routes.py
+++ b/tests/test_dataset_routes.py
@@ -93,7 +93,7 @@ async def test_update_dataset(client_test, dataset_data):
 
 
 @pytest.mark.asyncio
-async def test_delete_dataset(client_test, dataset_data):
+async def test_delete_dataset(client_test, dataset_data, test_user_access_token):
     """Testing the dataset delete route for deleting a dataset record"""
 
     # add a dataset record to the db
@@ -106,6 +106,12 @@ async def test_delete_dataset(client_test, dataset_data):
     assert response.status_code == 200
     # there should not be any submission records in the db
     assert await Submission.find_many().count() == 0
+    user = await User.find_one(User.access_token == test_user_access_token, fetch_links=True)
+    assert len(user.submissions) == 0
+
+    # retrieve all submissions for the current user from the db
+    submission_response = await client_test.get("api/catalog/submission")
+    assert submission_response.status_code == 200
 
 
 @pytest.mark.parametrize("multiple", [True, False])


### PR DESCRIPTION
For some reason when we delete a **submission** record, the reference to that submission record in **user** record is not getting removed. With the latest version of beanie that causes issues when we try to list submission for a given user. However, it seems to work with beanie 1.19.0. 

**UPDATE**: Found the bug for the reference to **submission** not getting removed from the **user** record when the submission is deleted. Last commit fixes that bug. I also pinned beanie to version 1.19.0 as it seems beanie version > 1.19.0 is using pydantic v2.