### PR TITLE
[#95] - add registration of existing metadata files stored on S3

### DIFF
--- a/api/adapters/__init__.py
+++ b/api/adapters/__init__.py
@@ -1,2 +1,3 @@
 # import all adapters here to get them registered
 from api.adapters import hydroshare
+from api.adapters import s3

--- a/api/adapters/s3.py
+++ b/api/adapters/s3.py
@@ -1,0 +1,51 @@
+import boto3
+import json
+from botocore.client import Config
+from botocore import UNSIGNED
+
+from api.adapters.base import AbstractRepositoryMetadataAdapter, AbstractRepositoryRequestHandler
+from api.adapters.utils import RepositoryType, register_adapter
+from api.models.catalog import DatasetMetadataDOC
+from api.models.user import Submission
+
+
+class _S3RequestHandler(AbstractRepositoryRequestHandler):
+    
+    def get_metadata(self, record_id: str):
+        endpoint_url = record_id.split("+")[0]
+        bucket_name = record_id.split("+")[1]
+        file_key = record_id.split("+")[2]
+
+        s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED), endpoint_url=endpoint_url)
+        
+        response = s3.get_object(Bucket=bucket_name, Key=file_key)
+        json_content = response['Body'].read().decode('utf-8')
+
+        # Parse the JSON content
+        data = json.loads(json_content)
+
+        return data
+
+
+class S3MetadataAdapter(AbstractRepositoryMetadataAdapter):
+    repo_api_handler = _S3RequestHandler()
+
+    @staticmethod
+    def to_catalog_record(metadata: dict) -> DatasetMetadataDOC:
+        return DatasetMetadataDOC(**metadata)
+
+    @staticmethod
+    def to_repository_record(catalog_record: DatasetMetadataDOC):
+        """Converts dataset catalog record to hydroshare resource metadata"""
+        raise NotImplementedError
+
+    @staticmethod
+    def update_submission(submission: Submission, repo_record_id: str) -> Submission:
+        """Sets additional hydroshare specific metadata to submission record"""
+
+        submission.repository_identifier = repo_record_id
+        submission.repository = RepositoryType.S3
+        return submission
+
+
+register_adapter(RepositoryType.S3, S3MetadataAdapter)

--- a/api/adapters/utils.py
+++ b/api/adapters/utils.py
@@ -6,6 +6,7 @@ from api.adapters.base import AbstractRepositoryMetadataAdapter
 
 class RepositoryType(str, Enum):
     HYDROSHARE = 'HYDROSHARE'
+    S3 = 'S3'
 
 
 _adapter_registry = {}

--- a/docker/requirements/api.txt
+++ b/docker/requirements/api.txt
@@ -4,3 +4,4 @@ motor
 beanie[httpx]==1.19.0
 python-jose
 pydantic<2.*
+boto3

--- a/docker/requirements/triggers.txt
+++ b/docker/requirements/triggers.txt
@@ -5,3 +5,4 @@ motor
 pydantic[dotenv]<2.*
 pydantic[email]<2.*
 rocketry==2.5.1
+boto3


### PR DESCRIPTION
I'm going to wire up an endpoint that submits a metadata extraction workflow before registering.  This assumes that the bucket path is publicly accessible and the metadata has already extracted.  The updated endpoint will accept a public path, run the metadata extraction and collect the results.