### PR TITLE
[#129] Track submission type of cataloged records

### DIFF
--- a/api/adapters/hydroshare.py
+++ b/api/adapters/hydroshare.py
@@ -8,7 +8,7 @@ from api.adapters.utils import RepositoryType, register_adapter
 from api.exceptions import RepositoryException
 from api.models import schema
 from api.models.catalog import DatasetMetadataDOC
-from api.models.user import Submission
+from api.models.user import Submission, SubmissionType
 
 
 class Creator(BaseModel):
@@ -163,7 +163,6 @@ class Rights(BaseModel):
 
 
 class _HydroshareRequestHandler(AbstractRepositoryRequestHandler):
-
     def get_metadata(self, record_id: str):
         hs_meta_url = self.settings.hydroshare_meta_read_url % record_id
         hs_file_url = self.settings.hydroshare_file_read_url % record_id
@@ -211,6 +210,7 @@ class HydroshareMetadataAdapter(AbstractRepositoryMetadataAdapter):
 
         submission.repository_identifier = repo_record_id
         submission.repository = RepositoryType.HYDROSHARE
+        submission.type = SubmissionType.HYDROSHARE
         return submission
 
 

--- a/api/adapters/s3.py
+++ b/api/adapters/s3.py
@@ -6,11 +6,10 @@ from botocore import UNSIGNED
 from api.adapters.base import AbstractRepositoryMetadataAdapter, AbstractRepositoryRequestHandler
 from api.adapters.utils import RepositoryType, register_adapter
 from api.models.catalog import DatasetMetadataDOC
-from api.models.user import Submission
+from api.models.user import Submission, SubmissionType
 
 
 class _S3RequestHandler(AbstractRepositoryRequestHandler):
-    
     def get_metadata(self, record_id: str):
         endpoint_url = record_id.split("+")[0]
         bucket_name = record_id.split("+")[1]
@@ -45,6 +44,7 @@ class S3MetadataAdapter(AbstractRepositoryMetadataAdapter):
 
         submission.repository_identifier = repo_record_id
         submission.repository = RepositoryType.S3
+        submission.type = SubmissionType.S3
         return submission
 
 

--- a/api/models/catalog.py
+++ b/api/models/catalog.py
@@ -7,6 +7,10 @@ from .schema import CoreMetadata, DatasetMetadata
 
 
 class CoreMetadataDOC(Document, CoreMetadata):
+    # this field is not stored in the database, but is populated from the corresponding submission record
+    # using the type field in the submission record
+    submission_type: str = None
+
     class Settings:
         # name is the collection name in database (iguide) where the Metadata Record documents will be stored
         # for all metadata record types (e.g. dataset, geopackage, software etc.)

--- a/api/models/user.py
+++ b/api/models/user.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
 
 from beanie import Document, Link, PydanticObjectId
@@ -9,6 +10,12 @@ if TYPE_CHECKING:
     from api.adapters.utils import RepositoryType
 
 
+class SubmissionType(str, Enum):
+    HYDROSHARE = 'HYDROSHARE'
+    S3 = 'S3'
+    IGUIDE_FORM = 'IGUIDE_FORM'
+
+
 class Submission(Document):
     title: str = None
     authors: List[str] = []
@@ -16,6 +23,7 @@ class Submission(Document):
     submitted: datetime = datetime.utcnow()
     url: HttpUrl = None
     repository: Optional[str]
+    type: SubmissionType = SubmissionType.IGUIDE_FORM
     repository_identifier: Optional[str]
 
 


### PR DESCRIPTION
Currently the following 3 submission types are supported:

- S3
- HYDROSHARE
- IGUIDE_FORM

The '`type`' field of a submission record has the value for the submission type (one of the above values)
The '`submission_type`' field of metadata record (dataset) has the value for the submission type (one of the above values)
 