### PR TITLE
[#144] Citation text wrapping

### DIFF
--- a/frontend/src/components/dataset/cd.dataset.vue
+++ b/frontend/src/components/dataset/cd.dataset.vue
@@ -1175,7 +1175,7 @@ export default toNative(CdDataset);
 
 .citation-text {
   min-width: 0;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 #graph-container {


### PR DESCRIPTION
Use `break-word` in citation text

![image](https://github.com/I-GUIDE/catalog/assets/2448568/2dabd552-00ad-4710-be9c-c754b846e79d)
