### PR TITLE
[#159] Store dataset source storage location in discovery collection

### DIFF
--- a/api/models/user.py
+++ b/api/models/user.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional, TYPE_CHECKING
@@ -14,6 +15,56 @@ class SubmissionType(str, Enum):
     HYDROSHARE = 'HYDROSHARE'
     S3 = 'S3'
     IGUIDE_FORM = 'IGUIDE_FORM'
+
+
+class StorageProvider(str, Enum):
+    AWS = "AWS"
+    GCP = "GCP"
+    Azure = "Azure"
+    GoogleDrive = "Google Drive"
+    Dropbox = "Dropbox"
+    OneDrive = "OneDrive"
+    Box = "Box"
+    CUAHSI = "CUAHSI"
+
+
+@dataclass
+class ContentStorage:
+    url_pattern: str
+    storage_name: str
+
+    @classmethod
+    def get_storage(cls, storage_provider: StorageProvider):
+        if storage_provider == StorageProvider.AWS:
+            return cls("amazonaws.com", "AWS")
+
+        if storage_provider == StorageProvider.GCP:
+            return cls("storage.googleapis.com", "GCP")
+
+        if storage_provider == StorageProvider.Azure:
+            return cls("blob.core.windows.net", "Azure")
+
+        if storage_provider == StorageProvider.GoogleDrive:
+            return cls("drive.google.com", "Google Drive")
+
+        if storage_provider == StorageProvider.Dropbox:
+            return cls("dropbox.com", "Dropbox")
+
+        if storage_provider == StorageProvider.OneDrive:
+            return cls("onedrive.live.com", "OneDrive")
+
+        if storage_provider == StorageProvider.Box:
+            return cls("app.box.com", "Box")
+
+        if storage_provider == StorageProvider.CUAHSI:
+            return cls("minio.cuahsi.io", "CUAHSI")
+
+    def get_storage_name(self, url: Optional[str], repository_identifier: Optional[str]):
+        if repository_identifier and self.url_pattern in repository_identifier:
+            return self.storage_name
+        if url and self.url_pattern in url:
+            return self.storage_name
+        return None
 
 
 class S3Path(BaseModel):
@@ -40,6 +91,61 @@ class Submission(Document):
     repository: Optional[str]
     repository_identifier: Optional[str]
     s3_path: Optional[S3Path]
+
+    @property
+    def content_location(self):
+        # determine the content location based on the repository type
+        if self.repository == SubmissionType.HYDROSHARE:
+            return self.repository
+        elif self.repository == SubmissionType.S3:
+            endpoint_url = self.s3_path.endpoint_url.rstrip("/")
+            storage = ContentStorage.get_storage(StorageProvider.AWS)
+            if endpoint_url.endswith(storage.url_pattern):
+                return storage.storage_name
+            storage = ContentStorage.get_storage(StorageProvider.CUAHSI)
+            if endpoint_url.endswith(storage.url_pattern):
+                return storage.storage_name
+            return self.repository
+
+        # determine the content location based on the URL or repository identifier
+
+        # check for GCP
+        storage = ContentStorage.get_storage(StorageProvider.GCP)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        # check for Azure
+        storage = ContentStorage.get_storage(StorageProvider.Azure)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        # check for Google Drive
+        storage = ContentStorage.get_storage(StorageProvider.GoogleDrive)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        # check for dropbox
+        storage = ContentStorage.get_storage(StorageProvider.Dropbox)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        # check for one drive
+        storage = ContentStorage.get_storage(StorageProvider.OneDrive)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        # check for box
+        storage = ContentStorage.get_storage(StorageProvider.Box)
+        storage_name = storage.get_storage_name(self.url, self.repository_identifier)
+        if storage_name:
+            return storage_name
+
+        return self.repository
 
 
 class User(Document):

--- a/triggers/update_catalog.py
+++ b/triggers/update_catalog.py
@@ -46,6 +46,9 @@ async def watch_catalog(db: AsyncIOMotorClient):
                     submission: Submission = await Submission.find_one({"identifier": document["_id"]})
                 catalog_entry["registrationDate"] = submission.submitted
                 catalog_entry["name_for_sorting"] = str.lower(catalog_entry["name"])
+                catalog_entry["submission_type"] = submission.repository
+                # location of the dataset files e.g. AWS,GCP, Azure, Hydroshare, CUAHSI, etc.
+                catalog_entry["content_location"] = submission.content_location
                 await db["discovery"].find_one_and_replace(
                         {"_id": document["_id"]}, catalog_entry, upsert=True
                     )


### PR DESCRIPTION
The `content_location` attribute of records in search results can be used to display appropriate storage icons. 